### PR TITLE
fix pip dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ scapy>=2.5.0
 jinja2>=3.1.4
 PyYAML>=6.0.2
 aiohttp>=3.10.5
+requests>=2.0.0


### PR DESCRIPTION
`requests` module missing in `requirements.txt`

error message in a newly build docker container:
```
trapster-community  | Traceback (most recent call last):
trapster-community  |   File "/app/main.py", line 4, in <module>
trapster-community  |     from trapster.trapster import main
trapster-community  |   File "/app/trapster/trapster.py", line 7, in <module>
trapster-community  |     from .modules import *
trapster-community  |   File "/app/trapster/modules/__init__.py", line 2, in <module>
trapster-community  |     from .http import HttpHoneypot
trapster-community  |   File "/app/trapster/modules/http.py", line 10, in <module>
trapster-community  |     from .libs import ai
trapster-community  |   File "/app/trapster/modules/libs/ai.py", line 2, in <module>
trapster-community  |     import requests
trapster-community  | ModuleNotFoundError: No module named 'requests'
```